### PR TITLE
Reduce unnecessary requests to remote cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ func main() {
 		options.Scheme = scheme
 	})
 	if err != nil {
-		log.Fatal("Failed to create management cluster")
+		log.Fatal(err)
 	}
 	localConfig, err = rest.InClusterConfig()
 	if err != nil {


### PR DESCRIPTION
Currently, sync-controller always attempts to patch the remote cluster with updated generation annotations, even when the annotations haven't changed. This PR prevents the unnecessary patch request.