### PR TITLE
Add label selection to reconciler

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -126,6 +127,9 @@ type Reconciler struct {
 	LocalPropagationPolicy client.PropagationPolicy
 	// ConcurrentReconciles sets the number of concurrent reconciles.
 	ConcurrentReconciles int
+	// LabelSelector is used to determine if the given resource should be synced based
+	// on configured labels. Defaults to selecting all.
+	LabelSelector metav1.LabelSelector
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -189,10 +193,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.
 		return ctrl.Result{}, nil
 	}
 
+	labelsMatch, err := r.matchesLabelSelector(remote)
+	if err != nil {
+		log.Error(err, "(remote) invalid label selector")
+		return ctrl.Result{}, trace.Wrap(err)
+	}
+
 	// If remote is missing or being deleted, delete local namespace or resource and quit.
 	// The namespace is only deleted if its owning resource is being deleted.
 	if creationTime(remote).IsZero() ||
-		!remote.GetDeletionTimestamp().IsZero() {
+		!remote.GetDeletionTimestamp().IsZero() ||
+		!labelsMatch {
 
 		// Delete namespace if present and created for this resource.
 		// Otherwise, just delete the resource if it exists.
@@ -371,6 +382,14 @@ func (r *Reconciler) filterLocalSecrets(obj client.Object) bool {
 		}
 	}
 	return false
+}
+
+func (r *Reconciler) matchesLabelSelector(obj client.Object) (bool, error) {
+	selector, err := metav1.LabelSelectorAsSelector(&r.LabelSelector)
+	if err != nil {
+		return false, err
+	}
+	return selector.Matches(labels.Set(obj.GetLabels())), nil
 }
 
 // addFinalizer adds a finalizer to the remote resource.

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -77,6 +77,8 @@ func TestSync(t *testing.T) {
 		remoteIn, remoteOut client.Object
 		localIn, localOut   client.Object
 
+		labelSelector metav1.LabelSelector
+
 		localSecretsIn   []*corev1.Secret
 		remoteSecretsOut []*corev1.Secret
 
@@ -422,8 +424,94 @@ func TestSync(t *testing.T) {
 			remoteSecretsOut:   nil,
 			skipNamespaceOwner: true,
 		},
+		{
+			desc: "Remote label selector mismatch deletes local",
+			remoteIn: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"sync": "no"},
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: toIntstr(2),
+				},
+				Status: policyv1.PodDisruptionBudgetStatus{
+					CurrentHealthy: 2,
+				},
+			},
+			remoteOut: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"sync": "no"},
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: toIntstr(2),
+				},
+				Status: policyv1.PodDisruptionBudgetStatus{
+					CurrentHealthy: 2,
+				},
+			},
+			localIn: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: toIntstr(2),
+				},
+				Status: policyv1.PodDisruptionBudgetStatus{
+					CurrentHealthy: 2,
+				},
+			},
+			localOut: &policyv1.PodDisruptionBudget{},
+			labelSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"sync": "yes"},
+			},
+			remoteSecretsOut: nil,
+		},
+		{
+			desc: "Remote label selector match creates local",
+			remoteIn: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"sync": "yes"},
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: toIntstr(2),
+				},
+				Status: policyv1.PodDisruptionBudgetStatus{
+					CurrentHealthy: 0,
+				},
+			},
+			remoteOut: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:     map[string]string{"sync": "yes"},
+					Finalizers: []string{FinalizerRemote},
+					Annotations: map[string]string{
+						AnnotationLocalGeneration:  "2",
+						AnnotationRemoteGeneration: "1",
+					},
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: toIntstr(2),
+				},
+				Status: policyv1.PodDisruptionBudgetStatus{
+					CurrentHealthy: 0,
+				},
+			},
+			localIn: &policyv1.PodDisruptionBudget{},
+			localOut: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"sync": "yes"},
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: toIntstr(2),
+				},
+				Status: policyv1.PodDisruptionBudgetStatus{
+					CurrentHealthy: 0,
+				},
+			},
+			labelSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"sync": "yes"},
+			},
+			remoteSecretsOut: nil,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			r.LabelSelector = tc.labelSelector
+
 			// Create namespaces with input values
 			remoteNs, localNs := setupTestCase(t, ctx, &setupConfig{
 				client:               testClient,


### PR DESCRIPTION
This adds the ability for sync-controller to only sync based on remote labels. If enabled, any locals will be deleted if the remote does not match the label selector. The default behavior for the label selector selects all which matches existing behavior.